### PR TITLE
✨ [FEAT] : 회원가입 이메일 인증 API 구현

### DIFF
--- a/src/main/java/OMNM/OMNMBACKEND/findUser/service/EmailService.java
+++ b/src/main/java/OMNM/OMNMBACKEND/findUser/service/EmailService.java
@@ -2,6 +2,8 @@ package OMNM.OMNMBACKEND.findUser.service;
 
 import OMNM.OMNMBACKEND.findUser.dto.EmailDto;
 import OMNM.OMNMBACKEND.findUser.dto.FindLoginPwDto;
+import OMNM.OMNMBACKEND.validation.domain.Validation;
+import OMNM.OMNMBACKEND.validation.repository.ValidationRepository;
 import com.sun.istack.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.SimpleMailMessage;
@@ -10,6 +12,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
 import java.util.Random;
 
 @Service
@@ -19,6 +22,7 @@ public class EmailService {
 
     private final JavaMailSender javaMailSender;
     private final FindService findService;
+    private final ValidationRepository validationRepository;
 
     public StringBuilder setTempKey(){
         StringBuilder tempCode = new StringBuilder();
@@ -59,7 +63,12 @@ public class EmailService {
         emailDto.setTitle("[OMNM] 이메일 인증 관련 이메일입니다.");
         emailDto.setContent("안녕하세요, OMNM 입니다. 이메일 인증 관련 인증번호는 다음과 같습니다." + System.lineSeparator() + validationNumber + System.lineSeparator() + "감사합니다.");
 
-        // Redis Database에 인증번호 저장 과정 보류
+        // Validation DB에 인증번호 저장
+        Optional<Validation> validation = validationRepository.findByEmail(email);
+        Validation validationEntity = validation.get();
+        validationEntity.setValidationNumber(validationNumber);
+        validationEntity.setEmail(email);
+        validationRepository.save(validationEntity);
 
         return emailDto;
     }

--- a/src/main/java/OMNM/OMNMBACKEND/user/UserController.java
+++ b/src/main/java/OMNM/OMNMBACKEND/user/UserController.java
@@ -7,6 +7,7 @@ import OMNM.OMNMBACKEND.user.dto.LoginDto;
 import OMNM.OMNMBACKEND.user.dto.UserDto;
 import OMNM.OMNMBACKEND.user.service.UserService;
 import OMNM.OMNMBACKEND.utils.JwtTokenService;
+import OMNM.OMNMBACKEND.validation.service.ValidationService;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -30,6 +31,7 @@ public class UserController {
     private final AwsS3Service awsS3Service;
     private final JwtTokenService jwtTokenService;
     private final EmailService emailService;
+    private final ValidationService validationService;
 
     /**
      * 아이디
@@ -84,12 +86,17 @@ public class UserController {
 
     @PostMapping("/join/emailValidation/checkNumber")
     public ResponseEntity<String> checkValidationNumber(String email, int userValidationNumber){
-        int validationNumber = 123456;  // 원래는 Redis에서 꺼내와야하지만, 세팅 전이니 그냥 가정 (추후 교체 요망)
-        if(validationNumber == userValidationNumber){
-            return new ResponseEntity<>("인증번호가 일치합니다.", HttpStatus.OK);
+        Integer validationNumber = validationService.getValidationNumber(email);
+        if(validationNumber == null){
+            return new ResponseEntity<>("인증번호가 일치하지 않습니다.", HttpStatus.OK);
         }
         else{
-            return new ResponseEntity<>("인증번호가 일치하지 않습니다.", HttpStatus.OK);
+            if(validationNumber == userValidationNumber){
+                return new ResponseEntity<>("인증번호가 일치합니다.", HttpStatus.OK);
+            }
+            else{
+                return new ResponseEntity<>("인증번호가 일치하지 않습니다.", HttpStatus.OK);
+            }
         }
     }
 

--- a/src/main/java/OMNM/OMNMBACKEND/validation/domain/Validation.java
+++ b/src/main/java/OMNM/OMNMBACKEND/validation/domain/Validation.java
@@ -1,0 +1,22 @@
+package OMNM.OMNMBACKEND.validation.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@Entity
+@Getter @Setter
+@Table(name = "validation")
+public class Validation {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "validationId")
+    private Long validationId;
+
+    @Column(name = "email")
+    private String email;
+
+    @Column(name = "validationNumber")
+    private Integer validationNumber;
+}

--- a/src/main/java/OMNM/OMNMBACKEND/validation/repository/ValidationRepository.java
+++ b/src/main/java/OMNM/OMNMBACKEND/validation/repository/ValidationRepository.java
@@ -1,0 +1,12 @@
+package OMNM.OMNMBACKEND.validation.repository;
+
+import OMNM.OMNMBACKEND.validation.domain.Validation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ValidationRepository extends JpaRepository<Validation, Long> {
+    Optional<Validation> findByEmail(String email);
+}

--- a/src/main/java/OMNM/OMNMBACKEND/validation/service/ValidationService.java
+++ b/src/main/java/OMNM/OMNMBACKEND/validation/service/ValidationService.java
@@ -1,0 +1,22 @@
+package OMNM.OMNMBACKEND.validation.service;
+
+import OMNM.OMNMBACKEND.validation.domain.Validation;
+import OMNM.OMNMBACKEND.validation.repository.ValidationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ValidationService {
+
+    private final ValidationRepository validationRepository;
+
+    public Integer getValidationNumber(String email){
+        Optional<Validation> validation = validationRepository.findByEmail(email);
+        return validation.map(Validation::getValidationNumber).orElse(null);
+    }
+}


### PR DESCRIPTION
## 제목
✨ [FEAT] : 회원가입 이메일 인증 API 구현
## 작업내용
- [x] 기능 추가
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 기타 설정

## 수정내용
1. 이메일 송신 시, 인증번호 DB에 저장 구현
2. 인증번호 체크하는 API 구현
-

## 주의 사항
1. Redis를 사용하지 않고 mySQL DB를 사용 (나중에 완성도 있는 프로젝트를 위해선 수정 필요)